### PR TITLE
Fix error on undefined parameters context

### DIFF
--- a/backend/lib/assistant-backend-stack.ts
+++ b/backend/lib/assistant-backend-stack.ts
@@ -25,10 +25,13 @@ export class AssistantBackendStack extends cdk.Stack {
 
     // -----------------------------------------------------------------------
     // Create relevant SSM parameters
-    const parameters = this.node.tryGetContext("parameters");
-
-    const BEDROCK_REGION = parameters["bedrock_region"] || "eu-central-1";
-    const LLM_MODEL_ID = parameters["llm_model_id"] || "anthropic.claude-v2";
+    const parameters = this.node.tryGetContext("parameters") || {
+        "bedrock_region": "eu-central-1",
+        "llm_model_id": "anthropic.claude-v2"
+      };
+  
+    const BEDROCK_REGION = parameters["bedrock_region"];
+    const LLM_MODEL_ID = parameters["llm_model_id"];
 
     // Note: the SSM parameters for Bedrock region and endpoint are used
     // to setup a boto3 bedrock client for programmatic access to Bedrock APIs.


### PR DESCRIPTION
*Description of changes:* Added a fix for users that try to run `cdk deploy` without passing the `parameters` key as context. Before the fix users were getting an because `parameters` was undefined when the `bedrock_region` was being accessed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
