### PR TITLE
Fix lambda docker build platform issue

### DIFF
--- a/backend/lib/assistant-backend-stack.ts
+++ b/backend/lib/assistant-backend-stack.ts
@@ -27,10 +27,10 @@ export class AssistantBackendStack extends cdk.Stack {
     // -----------------------------------------------------------------------
     // Create relevant SSM parameters
     const parameters = this.node.tryGetContext("parameters") || {
-        "bedrock_region": "eu-central-1",
-        "llm_model_id": "anthropic.claude-v2"
-      };
-  
+      "bedrock_region": "eu-central-1",
+      "llm_model_id": "anthropic.claude-v2"
+    };
+
     const BEDROCK_REGION = parameters["bedrock_region"];
     const LLM_MODEL_ID = parameters["llm_model_id"];
 
@@ -189,7 +189,10 @@ export class AssistantBackendStack extends cdk.Stack {
           path.join(
             __dirname,
             "lambda-functions/agent-executor-lambda-container"
-          )
+          ),
+          {
+            buildArgs: { "--platform": "linux/amd64" }
+          }
         ),
         description: "Lambda function with bedrock access created via CDK",
         timeout: cdk.Duration.minutes(5),

--- a/backend/lib/lambda-functions/agent-executor-lambda-container/Dockerfile
+++ b/backend/lib/lambda-functions/agent-executor-lambda-container/Dockerfile
@@ -1,5 +1,5 @@
 # stage 1: build the lambda layer
-FROM public.ecr.aws/lambda/python:3.9 AS builder
+FROM --platform=linux/x86_64 public.ecr.aws/lambda/python:3.9 AS builder
 
 # Copy requirements.txt
 COPY requirements.txt /tmp/
@@ -16,7 +16,7 @@ RUN yum install -y zip
 RUN cd /build/python && zip -r /opt/bedrock_layer.zip .
 
 # Stage 2: Build the Lambda function
-FROM public.ecr.aws/lambda/python:3.9
+FROM --platform=linux/x86_64 public.ecr.aws/lambda/python:3.9
 
 # Copy the Lambda layer artifacts from the builder stage
 COPY --from=builder /opt/bedrock_layer.zip /opt/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Current CDK lambda docker image builds are failing in MacOSX (or any platform other than `linux/x86_64`) due to platform mismatch. This change fixes this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
